### PR TITLE
Docker layerの最適化とキャッシュ削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM archlinuxjp/archlinux:start
+FROM archlinuxjp/archlinux:latest
 CMD /bin/bash
 ENV PATH $PATH
-RUN pacman -Sy archlinux-keyring --noconfirm
-RUN pacman-key --refresh-keys
-RUN pacman-db-upgrade
-RUN trust extract-compat
-RUN pacman -Syu --noconfirm
+
+RUN pacman -Sy archlinux-keyring --noconfirm && \
+      pacman-key --refresh-keys && \
+      pacman-db-upgrade && \
+      trust extract-compat && \
+      pacman -Syu --noconfirm && \
+      yes y | pacman -Scc && \
+      yes o | pacdiff

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ RUN pacman -Sy archlinux-keyring --noconfirm && \
       pacman-db-upgrade && \
       trust extract-compat && \
       pacman -Syu --noconfirm && \
-      yes y | pacman -Scc && \
-      yes o | pacdiff
+      yes y | pacman -Scc


### PR DESCRIPTION
ArchLinuxのdockerイメージの軽量化を行いました．

- `RUN`を1行に
- `/var/cache/pacman/pkg/*`等々の削除
- `*.pacnew`系の削除